### PR TITLE
duplication of SMB ratio for tags

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -1941,7 +1941,7 @@ var maxDelta_bg_threshold;
             //if (profile.bolus_increment) { bolusIncrement=profile.bolus_increment };
             var roundSMBTo = 1 / bolusIncrement;
 
-            var smb_ratio = profile.smb_delivery_ratio;
+            var smb_ratio = Math.min(profile.smb_delivery_ratio, 1);
 
             if (smb_ratio > 0.5) {
                 console.error("SMB Delivery Ratio increased from default 0.5 to " + round(smb_ratio,2))


### PR DESCRIPTION
Some duplication that leads to a repeated tag in popup and also missaligns the popup, due to conclusion semicolon in wrong place.
| bug | solution |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-06 at 00 37 07](https://github.com/nightscout/open-iaps-oref/assets/539276/f8203cb8-3a89-4679-80d5-d4273b58f695) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-06 at 00 42 33](https://github.com/nightscout/open-iaps-oref/assets/539276/d045c932-aa90-4504-bbe1-c35bc651f3d4) |