### PR TITLE
determine-basal.js: remove ineffective limit in tddReason for SMB Ratio

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -754,7 +754,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     else if (dynISFenabled && !profile.tddAdjBasal) { tddReason += log_isfCR + formula + limitLog + afLog; }
 
     if (0.5 !== profile.smb_delivery_ratio) {
-        tddReason += ", SMB Ratio: " + Math.min(profile.smb_delivery_ratio, 1);
+        tddReason += ", SMB Ratio: " + profile.smb_delivery_ratio;
     }
 
     // Not confident but something like this in iAPS v3.0.3


### PR DESCRIPTION
The limit imposed by `tddReason += ", SMB Ratio: " + Math.min(profile.smb_delivery_ratio, 1)` only affected log output, and was not limiting the actual range of smb_delivery_ratio. If a limit is needed for smb_delivery_ratio, it must be added elsewhere.