### PR TITLE
Revert "actualDate" changes to lib/meal/history.js

### DIFF
--- a/lib/meal/history.js
+++ b/lib/meal/history.js
@@ -24,18 +24,12 @@ function findMealInputs (inputs) {
 
     for (var i=0; i < carbHistory.length; i++) {
         var current = carbHistory[i];
-        if (current.carbs && current.actualDate) {
-            var temp = {};
-            temp.timestamp = current.actualDate;
-            temp.carbs = current.carbs;
-            temp.nsCarbs = current.carbs;
-        } else if (current.carbs && current.created_at) {
+        if (current.carbs && current.created_at) {
             var temp = {};
             temp.timestamp = current.created_at;
             temp.carbs = current.carbs;
             temp.nsCarbs = current.carbs;
-        if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.created_at,"carbs") ||
-            !arrayHasElementWithSameTimestampAndProperty(mealInputs, current.actualDate,"carbs")) {
+        if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.created_at,"carbs")) {
                 mealInputs.push(temp);
             } else {
                 duplicates += 1;
@@ -61,7 +55,8 @@ function findMealInputs (inputs) {
             // More specifically, we need to make sure we process the corresponding bolus entry first.
             bolusWizardInputs.push(current);
 
-        } else if ((current._type === "Meal Bolus" || current._type === "Correction Bolus" || current._type === "Snack Bolus" || current._type === "Bolus Wizard" || current._type === "Carb Correction") && current.created_at || current.actualDate) {            //imports carbs entered through Nightscout Care Portal
+        } else if ((current._type === "Meal Bolus" || current._type === "Correction Bolus" || current._type === "Snack Bolus" || current._type === "Bolus Wizard" || current._type === "Carb Correction") && current.created_at) {
+            //imports carbs entered through Nightscout Care Portal
             //"Bolus Wizard" refers to the Nightscout Bolus Wizard, not the Medtronic Bolus Wizard
             temp = {};
             temp.timestamp = current.created_at;
@@ -89,7 +84,7 @@ function findMealInputs (inputs) {
             temp = {};
             temp.carbs = current.carbs;
             temp.nsCarbs = current.carbs;
-            temp.timestamp = current.actualDate || current.created_at;
+            temp.timestamp = current.created_at;
             temp.bolus = current.insulin;
             if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"carbs")) {
                 mealInputs.push(temp);
@@ -98,7 +93,7 @@ function findMealInputs (inputs) {
             }
         } else if (current._type === "JournalEntryMealMarker" && current.carb_input > 0 && current.timestamp) {
             temp = {};
-            temp.timestamp = current.actualDate || current.created_at;
+            temp.timestamp = current.timestamp;
             temp.carbs = current.carb_input;
             temp.journalCarbs = current.carb_input;
             if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"carbs")) {


### PR DESCRIPTION
This partially reverts "Updated oref2 files based on findings in minimised files in iAPS v3.0.3", commit 05a1a2e4d7e431cb0035780c33dfd2a2c2b50f36.

The "actualDate" changes are not relevat to the starting point of the Open-iAPS fork, based on iAPS v2.3.3