### PR TITLE
fix threshold console.error

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -1019,7 +1019,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     threshold = min_bg - 0.5*(min_bg-40);
     // Set threshold to the user's setting, as long as it's between 60-120 and above the default calculated threshold
     threshold = Math.min(Math.max(profile.threshold_setting, threshold, 60), 120);
-    console.error("Threshold set to ${convert_bg(threshold, profile)}");
+    console.error(`Threshold set to ${convert_bg(threshold, profile)}`);
 
 // If iob_data or its required properties are missing, return.
 // This has to be checked after checking that we're not in one of the CGM-data-related error conditions handled above,


### PR DESCRIPTION
Example of log before this PR:
`2024-04-13T09:52:36-0400 [OpenAPS] JavaScriptWorker.swift - createContext() - 23 - DEV: JavaScript log: Threshold set to ${convert_bg(threshold, profile)}`

Example of log after this PR:
`2024-04-13T09:46:01-0400 [OpenAPS] JavaScriptWorker.swift - createContext() - 23 - DEV: JavaScript log: Threshold set to 75`