### PR TITLE
rename smbIsAlwaysOff to smbIsScheduledOff

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -45,7 +45,7 @@ function convert_bg(value, profile)
     }
 }
 function enable_smb(profile, microBolusAllowed, meal_data, bg, target_bg, high_bg, oref_variables, time) {
-    if (oref_variables.smbIsOff){
+    if (oref_variables.smbIsScheduledOff){
         /* Below logic is related to profile overrides which can disable SMBs or disable them for a scheduled window.
          * SMBs will be disabled from [start, end), such that if an SMB is scheduled to be disabled from 10 AM to 2 PM,
          * an SMB will not be allowed from 10:00:00 until 1:59:59.
@@ -154,7 +154,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     const isfAndCr = oref2_variables.isfAndCr;
     const isf = oref2_variables.isf;
     const cr_ = oref2_variables.cr;
-    const smbIsAlwaysOff = oref2_variables.smbIsAlwaysOff;
+    const smbIsScheduledOff = oref2_variables.smbIsScheduledOff;
     const start = oref2_variables.start;
     var end = oref2_variables.end;
     const smbMinutes = oref2_variables.smbMinutes;
@@ -1162,7 +1162,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     let enableSMB = false;
 
     // If SMB is always off, don't bother checking if we should enable SMBs
-    if (smbIsAlwaysOff) {
+    if (smbIsOff) {
         console.error("SMBs are always off.");
         enableSMB = false;
     } else {


### PR DESCRIPTION
More importantly, it reverts the swapping of `smbIsOff` and ~~`smbIsAlwaysOff`~~`smbIsScheduledOff`

Must be merged in tandem with https://github.com/nightscout/Open-iAPS/pull/120