### PR TITLE
Separate Adjustment Factors for Logarithmic and Sigmoid

### DIFF
--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -68,7 +68,8 @@ function defaults ( ) {
     , target_bg: false // set to an integer value in mg/dL to override pump min_bg
     // autoISF variables
     , smb_delivery_ratio: 0.5 //Default value: 0.5 Used if flexible delivery ratio is not used. This is another key OpenAPS safety cap, and specifies what share of the total insulin required can be delivered as SMB. This is to prevent people from getting into dangerous territory by setting SMB requests from the caregivers phone at the same time. Increase this experimental value slowly and with caution.
-    , adjustmentFactor: 1
+    , adjustmentFactor: 0.8
+    , adjustmentFactorSigmoid: 0.5
     , useNewFormula: false
     , enableDynamicCR: false
     , sigmoid: false
@@ -102,6 +103,7 @@ function displayedDefaults () {
     profile.smb_delivery_ratio = allDefaults.smb_delivery_ratio;
     profile.maxDelta_bg_threshold = allDefaults.maxDelta_bg_threshold;
     profile.adjustmentFactor = allDefaults.adjustmentFactor;
+    profile.adjustmentFactorSigmoid = allDefaults.adjustmentFactorSigmoid;
     profile.useNewFormula = allDefaults.useNewFormula;
     profile.enableDynamicCR = allDefaults.enableDynamicCR;
     profile.sigmoid = allDefaults.sigmoid;


### PR DESCRIPTION
Addresses issue https://github.com/nightscout/Open-iAPS/issues/106 by using separate variables for Adjustment Factor when using Logarithmic DynamicISF vs Sigmoid DynamicISF. Defaults AF to 0.8 for Logarithmic and 0.6 for Sigmoid.

Pairs with this PR in Open-iAPS: https://github.com/nightscout/Open-iAPS/pull/114