### PR TITLE
skip_neutral_temps only if SMB's somehow disabled

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -1693,8 +1693,12 @@ var maxDelta_bg_threshold;
     // if not in LGS mode, cancel temps before the top of the hour to reduce beeping/vibration
     // console.error(profile.skip_neutral_temps, rT.deliverAt.getMinutes());
     if ( profile.skip_neutral_temps && rT.deliverAt.getMinutes() >= 55 ) {
-        rT.reason += "; Canceling temp at " + rT.deliverAt.getMinutes() + "m past the hour. ";
-        return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+        if (!enableSMB) {
+            rT.reason += "; Canceling temp at " + (60 - rT.deliverAt.getMinutes()) + "min before turn of the hour to avoid beeping of MDT. SMB are disabled anyways.";
+            return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+        } else {
+             console.error((60 - rT.deliverAt.getMinutes()) + "min before turn of the hour, but SMB's are enabled - not skipping neutral temps.")
+        }
     }
 
     var insulinReq = 0;


### PR DESCRIPTION
This contains an oref fix, which only enables this features if SMB's are disabled (by whatever reason). Because the functionality only makes sense if the MDT pump cannot make any noise anyways and SMB's will always make the pump beep and rattle. So if SMBs can be given there is no reason to skip neutral temps as it would be beeping because of an SMB.

Compare PR with oref PR discussion at https://github.com/openaps/oref0/pull/1452 and issue ticket https://github.com/openaps/oref0/issues/1451