### PR TITLE
Remove dynisf check on pumpdata calc

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -383,7 +383,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         console.log("Pumphistory is empty!");
         dynISFenabled = false;
         enableDynamicCR = false;
-    } else if (dynISFenabled) {
+    } else {
         let phLastEntry = pumphistory.length - 1;
         var endDate = new Date(pumphistory[phLastEntry].timestamp);
         var startDate = new Date(pumphistory[0].timestamp);


### PR DESCRIPTION
As of discussion in [Trio closed beta](https://discord.com/channels/1020905149037813862/1330638332161687562/1330663109295083553) removed check for enabled dynisf when calculating length of pumpData.