### PR TITLE
Increase precision for temp bolus calculation

### DIFF
--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -4,6 +4,11 @@ var basalprofile = require('../profile/basal.js');
 var _ = require('lodash');
 var moment = require('moment');
 
+function roundToDecimalPlaces(value, decimalPlaces) {
+    const multiplier = Math.pow(10, decimalPlaces);
+    return Math.round(value * multiplier) / multiplier;
+}
+
 function splitTimespanWithOneSplitter(event,splitter) {
 
     var resultArray = [event];
@@ -551,8 +556,9 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             var netBasalRate = currentItem.rate - currentRate;
             if (netBasalRate < 0) { tempBolusSize = -0.05; }
             else { tempBolusSize = 0.05; }
-            var netBasalAmount = Math.round(netBasalRate*currentItem.duration*10/6)/100
-            var tempBolusCount = Math.round(netBasalAmount / tempBolusSize);
+            var netBasalAmount = roundToDecimalPlaces(netBasalRate*currentItem.duration/60, 8);
+            var tempBolusCountPrecise = roundToDecimalPlaces(netBasalAmount / tempBolusSize, 8);
+            var tempBolusCount = Math.round(tempBolusCountPrecise);
             var tempBolusSpacing = currentItem.duration / tempBolusCount;
             for (j=0; j < tempBolusCount; j++) {
                 var tempBolus = {};

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -56,6 +56,45 @@ describe('IOB', function() {
         //afterDIA.bolussnooze.should.equal(0);
     });
 
+    it('should calculate IOB with Temp Basals', function() {
+
+        var basalprofile = [{
+            'i': 0,
+            'start': '00:00:00',
+            'rate': 1.25,
+            'minutes': 0
+        }];
+        var now = Date.now(),
+            timestamp = new Date(now).toISOString(),
+            timestamp30mAgo = new Date(now - (30 * 60 * 1000)).toISOString(),
+            inputs = {
+                clock: timestamp,
+                history: [{
+                    _type: 'TempBasal',
+                    rate: 0,
+                    date: timestamp30mAgo,
+                    timestamp: timestamp30mAgo
+                }, {
+                    _type: 'TempBasalDuration',
+                    'duration (min)': 30,
+                    date: timestamp30mAgo,
+                    timestamp: timestamp30mAgo
+                }],
+                profile: {
+                    dia: 3,
+                    current_basal: 1,
+                    max_daily_basal: 1,
+                    //bolussnooze_dia_divisor: 2,
+                    'basalprofile': basalprofile
+                }
+            };
+
+        var iobInputs = inputs;
+        var iobNow = iob(iobInputs)[0];
+        // 1.25 for 30m rounded to the nearest 0.05
+        iobNow.netbasalinsulin.should.equal(-0.65);
+    });
+
     it('should calculate IOB with Ultra-fast curve', function() {
 
         var basalprofile = [{


### PR DESCRIPTION
In general, Javascript is using floating point math but in Swift we use Decimal for higher precision. This particular calculation is a big source of differences where floating point vs Decimal can cause issues. It's common to get a 30m zero temp basal due to how the IoB algorithm splits up long temp basal commands, and if your rate ends in x.x5 oftentimes the Javascript rounding function rounds it differently than Decimal in swift.

This change includes a test case that shows where this imprecision can happen and proposes a fix.

As an alternative, we could just increase the thresholds we use for checking IoB equivalence in Swift vs Javascript, but this particular calculation happens to be the biggest source of differences currently.