### PR TITLE
Fix iob history splitting logic

### DIFF
--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -48,28 +48,27 @@ function splitTimespanWithOneSplitter(event,splitter) {
 }
 
 function splitTimespan(event, splitterMoments) {
-
     var results = [event];
+    var globalSplitFound = true;
 
-    var splitFound = true;
-
-    while(splitFound) {
-
+    while(globalSplitFound) {
         var resultArray = [];
-        splitFound = false;
+        globalSplitFound = false;
 
-        _.forEach(results,function split(o) {
-            _.forEach(splitterMoments,function split(p) {
-                var splitResult = splitTimespanWithOneSplitter(o,p);
+        _.forEach(results, function split(o) {
+            var localSplitFound = false;
+            
+            _.forEach(splitterMoments, function split(p) {
+                var splitResult = splitTimespanWithOneSplitter(o, p);
                 if (splitResult.length > 1) {
                     resultArray = resultArray.concat(splitResult);
-                    splitFound = true;
-                    return false;
+                    localSplitFound = true;
+                    globalSplitFound = true;
+                    return false;  // This exits only the inner forEach
                 }
             });
 
-            if (!splitFound) resultArray = resultArray.concat([o]);
-
+            if (!localSplitFound) resultArray = resultArray.concat([o]);
         });
 
         results = resultArray;

--- a/tests/iob-suspend.test.js
+++ b/tests/iob-suspend.test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+require('should');
+const moment = require('moment');
+const calcTempTreatments = require('../lib/iob/history');
+
+describe('Suspend Logic Tests with suspendZerosIob=true', function() {
+    // Helper function to create a basic basal profile
+    function createBasicBasalProfile() {
+        return [{
+            'start': '00:00:00',
+            'rate': 1,
+            'minutes': 0
+        }];
+    }
+
+    // Helper function to create a multi-rate basal profile
+    function createMultiRateBasalProfile() {
+        return [{
+            'start': '00:00:00',
+            'rate': 1,
+            'minutes': 0
+        }, {
+            'start': '00:30:00',
+            'rate': 2,
+            'minutes': 30
+        }];
+    }
+
+    it('should handle suspend with basal profile changes', function() {
+        const basalprofile = createMultiRateBasalProfile();
+        
+        // Start at 00:15, suspend at 00:30, resume at 00:45
+        const startTime = moment('2016-06-13 00:15:00').toDate();
+        const suspendTime = moment('2016-06-13 00:30:00').toDate();
+        const resumeTime = moment('2016-06-13 00:45:00').toDate();
+        const endTime = moment('2016-06-13 01:00:00').toDate();
+
+        const inputs = {
+            clock: endTime.toISOString(),
+            history: [
+                {
+                    _type: 'TempBasal',
+                    rate: 3,
+                    date: startTime.getTime(),
+                    timestamp: startTime.toISOString()
+                },
+                {
+                    _type: 'TempBasalDuration',
+                    'duration (min)': 45,
+                    date: startTime.getTime(),
+                    timestamp: startTime.toISOString()
+                },
+                {
+                    _type: 'PumpSuspend',
+                    date: suspendTime.getTime(),
+                    timestamp: suspendTime.toISOString()
+                },
+                {
+                    _type: 'PumpResume',
+                    date: resumeTime.getTime(),
+                    timestamp: resumeTime.toISOString()
+                }
+            ],
+            profile: {
+                current_basal: 1,
+                max_daily_basal: 2,
+                dia: 3,
+                basalprofile: basalprofile,
+                suspend_zeros_iob: true
+            }
+        };
+
+        const treatments = calcTempTreatments(inputs);
+
+        // Calculate expected insulin impact:
+        // 15m at 3 U/h - 1 U/h = 0.5U (from start to basal change)
+        // 15m at 0 U/h - 2 U/h = -0.5U (from basal change and suspend)
+        // 15m at 3 U/h - 2 U/h = 0.25U (resume to finish)
+        // Total: 0.25U
+        const tempBoluses = treatments.filter(t => t.insulin !== undefined);
+        const totalInsulin = tempBoluses.reduce((sum, bolus) => sum + bolus.insulin, 0);
+        totalInsulin.should.be.approximately(0.25, 0.05);
+    });
+
+    it('should handle suspend without basal profile changes', function() {
+        const basalprofile = createMultiRateBasalProfile();
+        
+        // Start at 00:30, suspend at 00:45, resume at 01:00
+        const startTime = moment('2016-06-13 00:30:00').toDate();
+        const suspendTime = moment('2016-06-13 00:45:00').toDate();
+        const resumeTime = moment('2016-06-13 01:00:00').toDate();
+        const endTime = moment('2016-06-13 01:15:00').toDate();
+
+        const inputs = {
+            clock: endTime.toISOString(),
+            history: [
+                {
+                    _type: 'TempBasal',
+                    rate: 3,
+                    date: startTime.getTime(),
+                    timestamp: startTime.toISOString()
+                },
+                {
+                    _type: 'TempBasalDuration',
+                    'duration (min)': 45,
+                    date: startTime.getTime(),
+                    timestamp: startTime.toISOString()
+                },
+                {
+                    _type: 'PumpSuspend',
+                    date: suspendTime.getTime(),
+                    timestamp: suspendTime.toISOString()
+                },
+                {
+                    _type: 'PumpResume',
+                    date: resumeTime.getTime(),
+                    timestamp: resumeTime.toISOString()
+                }
+            ],
+            profile: {
+                current_basal: 1,
+                max_daily_basal: 2,
+                dia: 3,
+                basalprofile: basalprofile,
+                suspend_zeros_iob: true
+            }
+        };
+
+        const treatments = calcTempTreatments(inputs);
+
+        // Calculate expected insulin impact:
+        // 15m at 3 U/h - 2 U/h = 0.25U (from start to basal change)
+        // 15m at 0 U/h - 2 U/h = -0.5U (from basal change and suspend)
+        // 15m at 3 U/h - 2 U/h = 0.25U (resume to finish)
+        // Total: 0U
+        const tempBoluses = treatments.filter(t => t.insulin !== undefined);
+        const totalInsulin = tempBoluses.reduce((sum, bolus) => sum + bolus.insulin, 0);
+        totalInsulin.should.be.approximately(0.0, 0.05);
+    });
+});

--- a/tests/iob-suspend.test.js
+++ b/tests/iob-suspend.test.js
@@ -130,8 +130,8 @@ describe('Suspend Logic Tests with suspendZerosIob=true', function() {
         const treatments = calcTempTreatments(inputs);
 
         // Calculate expected insulin impact:
-        // 15m at 3 U/h - 2 U/h = 0.25U (from start to basal change)
-        // 15m at 0 U/h - 2 U/h = -0.5U (from basal change and suspend)
+        // 15m at 3 U/h - 2 U/h = 0.25U (from start to suspend)
+        // 15m at 0 U/h - 2 U/h = -0.5U (from suspend to resume)
         // 15m at 3 U/h - 2 U/h = 0.25U (resume to finish)
         // Total: 0U
         const tempBoluses = treatments.filter(t => t.insulin !== undefined);

--- a/tests/iob-suspend.test.js
+++ b/tests/iob-suspend.test.js
@@ -61,7 +61,7 @@ describe('Suspend Logic Tests with suspendZerosIob=true', function() {
                     date: resumeTime.getTime(),
                     timestamp: resumeTime.toISOString()
                 }
-            ],
+            ].reverse(),
             profile: {
                 current_basal: 1,
                 max_daily_basal: 2,
@@ -117,7 +117,7 @@ describe('Suspend Logic Tests with suspendZerosIob=true', function() {
                     date: resumeTime.getTime(),
                     timestamp: resumeTime.toISOString()
                 }
-            ],
+            ].reverse(),
             profile: {
                 current_basal: 1,
                 max_daily_basal: 2,


### PR DESCRIPTION
This PR fixes a bug where the splitting logic can drop an event. The first test case demonstrates the issue with `splitTimeline`. It sends a temp basal that is 45 minutes with a basal profile split after 15 minutes. The logic will:

Start with:

`duration: 45`

Then split at 30m boundary:

`duration: 30`
`duration: 15`

Then at the next iteration in `splitTimeline` it will split the first event at the profile basal rate, but that sets `splitFound: true` but since the second event isn't split, it ends up getting dropped.

The fix is to separate out the logic for the current event split processing vs the while loop globally.