### PR TITLE
Remove 400 / shouldProtectDueToHIGH guard

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -78,10 +78,6 @@ function enable_smb(profile, microBolusAllowed, meal_data, bg, target_bg, high_b
     } else if (meal_data.bwFound === true && profile.A52_risk_enable === false) {
         console.error("SMB disabled due to Bolus Wizard activity in the last 6 hours.");
         return false;
-    // Disable if invalid CGM reading (HIGH)
-    } else if (!!trio_custom_variables.shouldProtectDueToHIGH) {
-        console.error("Invalid CGM (HIGH). SMBs disabled.");
-        return false;
     }
 
     // enable SMB/UAM if always-on (unless previously disabled for high temptarget)
@@ -1615,11 +1611,6 @@ var maxDelta_bg_threshold;
         }
 
         var maxSafeBasal = tempBasalFunctions.getMaxSafeBasal(profile);
-
-        // set neutral TBR at current basal rate because glucose is considered as requiring dosing Protect due to HIGH (400 mg/dL)
-        if (!!trio_custom_variables.shouldProtectDueToHIGH) {
-            return tempBasalFunctions.setTempBasal(profile.current_basal, 30, profile, rT, currenttemp);
-        }
 
         if (rate > maxSafeBasal) {
             rT.reason += "adj. req. rate: " + rate + " to maxSafeBasal: " + round(maxSafeBasal,2) + ", ";

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -440,13 +440,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 
-    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( glucose_status.short_avgdelta === 0 && glucose_status.long_avgdelta === 0 ) ) {
+    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5) {
         if (currenttemp.rate >= basal) { // high temp is running
-            rT.reason += ". Canceling high temp basal of " + currenttemp.rate;
+            rT.reason += ". Replacing high temp basal of "+currenttemp.rate+" with neutral temp of "+basal;
             rT.deliverAt = deliverAt;
             rT.temp = 'absolute';
-            rT.duration = 0;
-            rT.rate = 0;
+            rT.duration = 30;
+            rT.rate = basal;
             return rT;
             // don't use setTempBasal(), as it has logic that allows <120% high temps to continue running
             //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);


### PR DESCRIPTION
### Summary

This PR removes the remaining 400 guard (`shouldProtectDueToHIGH`) logic from the oref code used by Trio. The guard previously disabled SMBs and forced neutral temp basals when CGM values appeared as flatlined HIGH readings (>3 consecutive readings of 400 mg/dL).

### Changes

* Delete SMB-blocking branch in `enable_smb()` that returned `false` whenever `shouldProtectDueToHIGH` was set.
* Remove the temp-basal override that forced a neutral TBR when `shouldProtectDueToHIGH` was true.
* Remove condition `glucose_status.short_avgdelta === 0 && glucose_status.long_avgdelta === 0` to avoid early exits after 45min of consecutive 400 readings that would lead to unsuccessful determine-basal runs for Trio

### Rationale

The original guard was only meant as a temporary safety measure for suspicious HIGH readings. It’s no longer needed and diverges from upstream oref, so we’re removing it to restore standard oref behavior, to aid FCL users in underserved populations that semi-frequently run into situations where they get stuck on 400 mg/dL for a prolonged time period.